### PR TITLE
Update air purity to_string values to match expected values on ambi.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -55,10 +55,10 @@ impl AirPurity {
 impl fmt::Display for AirPurity {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            AirPurity::Low => write!(f, "LOW"),
-            AirPurity::High => write!(f, "HIGH"),
-            AirPurity::Dangerous => write!(f, "DANGEROUS"),
-            AirPurity::FreshAir => write!(f, "FRESH_AIR")
+            AirPurity::Low => write!(f, "Fresh Air"),
+            AirPurity::High => write!(f, "Low Pollution"),
+            AirPurity::Dangerous => write!(f, "High Pollution"),
+            AirPurity::FreshAir => write!(f, "Dangerous Pollution")
         }
     }
 }


### PR DESCRIPTION
Updates Mock client to use a set of air purity values which correctly match expected values on ambi app. Previously, ambi app would give an error "no cond clause evaluated to a truthy value" when reading entries from the DB. These DB entries came from the mock client and were faulty due to mismatched error purity values.

Correct entry values were taken from these lines in ambi:
https://github.com/Jim-Hodapp-Coaching/ambi/blob/afcef37ed7593084ac4aa0ad19ac65bb02ffacfc/lib/ambi_web/live/reading_live.html.leex#L77-L86