### PR TITLE
Added foundation of command line interface argument/flag parsing/handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ rand = "0.8.4"
 reqwest = { version = "0.11.9", features = ["blocking"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.74"
+clap = { version = "3.1.7", features = ["derive"] }
 
 [dev-dependencies]
 regex = "1.5.4"
+
+[lib]
+name = "ambi_mock_client"
+path = "src/lib.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,29 @@
+//! # Provides a mock Ambi client that emulates real sensor hardware such as like
+//! an Edge client.
+//!
+//! This file provides for a separation of concerns from main.rs for application
+//! logic, per the standard Rust pattern.
+//! 
+//! See `main.rs` for more details about what this application does.
+//!
+//! See the `LICENSE` file for Copyright and license details.
+//! 
+//! 
+use clap::{Parser};
+
+/// Defines the Ambi Mock Client command line interface as a struct
+#[derive(Parser, Debug)]
+#[clap(name = "Ambi Mock Client")]
+#[clap(author = "Rust Never Sleeps community (https://github.com/Jim-Hodapp-Coaching/)")]
+#[clap(version = "0.1.0")]
+#[clap(about = "Provides a mock Ambi client that emulates real sensor hardware such as an Edge client.")]
+#[clap(long_about = "This application emulates a real set of hardware sensors that can report on environmental conditions such as temperature, pressure, humidity, etc.")]
+pub struct Cli {
+    /// Turns verbose console debug output on
+    #[clap(short, long)]
+    pub debug: bool,
+}
+
+pub fn run(cli: &Cli) {
+    println!("\r\ncli: {:?}\r\n", cli);
+}


### PR DESCRIPTION
Added the use of the crate `clap` for command line interface argument/flag parsing.

[Clap reference](https://github.com/clap-rs/clap)

Provides `-d`|`--debug`, `-V`|`--version` and `-h`|`--help` with this changeset.

Refer to the `ambi_mock_client` [CLI design document](https://docs.google.com/document/d/1s8aV0F4EsFk9e6kstjuVdfV1ICH407ffTz5rbjKrqbw/edit) for more background info.

Also sets the foundation for separation of application logic now being in `lib.rs` instead of everything being in `main.rs`. See the [Rust book section 12.3](https://doc.rust-lang.org/book/ch12-03-improving-error-handling-and-modularity.html#splitting-code-into-a-library-crate) for more info.

## Example output

```
$ ambi_mock_client --help
Ambi Mock Client 0.1.0
Rust Never Sleeps community (https://github.com/Jim-Hodapp-Coaching/)
This application emulates a real set of hardware sensors that can report on environmental conditions
such as temperature, pressure, humidity, etc.

USAGE:
    ambi_mock_client [OPTIONS]

OPTIONS:
    -d, --debug
            Turns verbose console debug output on

    -h, --help
            Print help information

    -V, --version
            Print version information
```

or setting verbose debug output on:

```
$ ambi_mock_client -d
Debug mode is now *on*

cli: Cli { debug: true }

Sending POST request to http://localhost:4000/api/readings/add as JSON: {"temperature":"24.2","humidity":"70.1","pressure":"960","dust_concentration":"999","air_purity":"High Pollution"}
Response: Ok(
    Response {
        url: Url {
            scheme: "http",
            cannot_be_a_base: false,
            username: "",
            password: None,
            host: Some(
                Domain(
                    "localhost",
                ),
            ),
            port: Some(
                4000,
            ),
            path: "/api/readings/add",
            query: None,
            fragment: None,
        },
        status: 200,
        headers: {
            "cache-control": "max-age=0, private, must-revalidate",
            "content-length": "60",
            "content-type": "application/json; charset=utf-8",
            "date": "Thu, 31 Mar 2022 20:17:33 GMT",
            "server": "Cowboy",
            "x-request-id": "FuF_EewOgIHT5BkAAEfn",
        },
    },
)
```

Closes #5 