### PR TITLE
Add stronger types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,11 +15,23 @@ dependencies = [
 name = "ambi_mock_client"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "rand",
  "regex",
  "reqwest",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -63,6 +75,45 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e538f9ee5aa3b3963f09a997035f883677966ed50fce0292611927ce6f6d8c6"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f98063cac4652f23ccda556b8d04347a7fc4b2cff1f7577cc8c6546e0d8078"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
 
 [[package]]
 name = "core-foundation"
@@ -212,6 +263,12 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -488,6 +545,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +579,30 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -745,6 +832,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +861,21 @@ dependencies = [
  "remove_dir_all",
  "winapi",
 ]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "tinyvec"
@@ -895,6 +1003,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,6 +1115,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,36 +171,6 @@ pub fn run(cli: &Cli) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    // use regex::Regex;
-
-    // #[test]
-    // fn random_gen_humidity_returns_correctly_formatted_humidity_data() {
-    //     let result = random_gen_humidity();
-    //     let regex = Regex::new(r"\d{1,2}.\d{1}").unwrap();
-
-    //     assert!(regex.is_match(&result));
-    // }
-    // #[test]
-    // fn random_gen_temperature_returns_correctly_formatted_humidity_data() {
-    //     let result = random_gen_temperature();
-    //     let regex = Regex::new(r"\d{1,2}.\d{1}").unwrap();
-
-    //     assert!(regex.is_match(&result));
-    // }
-
-    // #[test]
-    // fn random_gen_pressure_returns_correctly_formatted_pressure_data() {
-    //     let result = random_gen_pressure();
-    //     let regex = Regex::new(r"\d{3,4}").unwrap();
-    //     assert!(regex.is_match(&result));
-    // }
-
-    // #[test]
-    // fn random_gen_dust_concentration_returns_correctly_formatted_pressure_data() {
-    //     let result = random_gen_dust_concentration();
-    //     let regex = Regex::new(r"\d{0,4}").unwrap();
-    //     assert!(regex.is_match(&result));
-    // }
 
     #[test]
     fn air_purity_from_value_returns_correct_enum() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,56 +3,59 @@
 //!
 //! This file provides for a separation of concerns from main.rs for application
 //! logic, per the standard Rust pattern.
-//! 
+//!
 //! See `main.rs` for more details about what this application does.
 //!
 //! See the `LICENSE` file for Copyright and license details.
-//! 
+//!
 
+use clap::Parser;
 use rand::{thread_rng, Rng};
 use reqwest::blocking::Client;
 use reqwest::header::CONTENT_TYPE;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use std::fmt;
-use clap::{Parser};
 
 /// Defines the Ambi Mock Client command line interface as a struct
 #[derive(Parser, Debug)]
 #[clap(name = "Ambi Mock Client")]
 #[clap(author = "Rust Never Sleeps community (https://github.com/Jim-Hodapp-Coaching/)")]
 #[clap(version = "0.1.0")]
-#[clap(about = "Provides a mock Ambi client that emulates real sensor hardware such as an Edge client.")]
-#[clap(long_about = "This application emulates a real set of hardware sensors that can report on environmental conditions such as temperature, pressure, humidity, etc.")]
+#[clap(
+    about = "Provides a mock Ambi client that emulates real sensor hardware such as an Edge client."
+)]
+#[clap(
+    long_about = "This application emulates a real set of hardware sensors that can report on environmental conditions such as temperature, pressure, humidity, etc."
+)]
 pub struct Cli {
     /// Turns verbose console debug output on
     #[clap(short, long)]
     pub debug: bool,
 }
 
-
 #[derive(Serialize, Deserialize)]
 struct Reading {
-  temperature: String,
-  humidity: String,
-  pressure: String,
-  dust_concentration: String,
-  air_purity: String
+    temperature: f64,
+    humidity: f64,
+    pressure: i32,
+    dust_concentration: i32,
+    air_purity: String,
 }
 
 impl Reading {
     fn new(
-        temperature: String,
-        humidity: String,
-        pressure: String,
-        dust_concentration: String,
-        air_purity: String
+        temperature: f64,
+        humidity: f64,
+        pressure: i32,
+        dust_concentration: i32,
+        air_purity: String,
     ) -> Reading {
         Reading {
             temperature,
             humidity,
             pressure,
             dust_concentration,
-            air_purity
+            air_purity,
         }
     }
 }
@@ -62,13 +65,13 @@ enum AirPurity {
     Dangerous,
     High,
     Low,
-    FreshAir
+    FreshAir,
 }
 
 impl AirPurity {
-    fn from_value(value: u16) -> AirPurity {
+    fn from_value(value: i32) -> AirPurity {
         match value {
-            0..=50 => return AirPurity::FreshAir,
+            i32::MIN..=50 => return AirPurity::FreshAir,
             51..=100 => return AirPurity::Low,
             101..=150 => return AirPurity::High,
             151.. => return AirPurity::Dangerous,
@@ -84,44 +87,46 @@ impl fmt::Display for AirPurity {
             AirPurity::Low => write!(f, "Fresh Air"),
             AirPurity::High => write!(f, "Low Pollution"),
             AirPurity::Dangerous => write!(f, "High Pollution"),
-            AirPurity::FreshAir => write!(f, "Dangerous Pollution")
+            AirPurity::FreshAir => write!(f, "Dangerous Pollution"),
         }
     }
 }
 
-fn random_gen_humidity() -> String {
+fn random_gen_humidity() -> f64 {
     let mut rng = thread_rng();
     let value = rng.gen_range(0.0..=100.0);
-    format!("{:.1}", value)
+    // Limit to 2 decimals
+    f64::trunc(value * 100.0) / 100.0
 }
 
-fn random_gen_temperature() -> String {
+fn random_gen_temperature() -> f64 {
     let mut rng = thread_rng();
     let value = rng.gen_range(15.0..=35.0);
-    format!("{:.1}", value)
+    // Limit to 2 decimals
+    f64::trunc(value * 100.0) / 100.0
 }
 
-fn random_gen_pressure() -> String {
+fn random_gen_pressure() -> i32 {
     let mut rng = thread_rng();
-    rng.gen_range(900..=1100).to_string()
+    rng.gen_range(900..=1100)
 }
 
-fn random_gen_dust_concentration() -> String {
+fn random_gen_dust_concentration() -> i32 {
     let mut rng = thread_rng();
-    rng.gen_range(0..=1000).to_string()
+    rng.gen_range(0..=1000)
 }
 
 pub fn run(cli: &Cli) {
     println!("\r\ncli: {:?}\r\n", cli);
 
     let dust_concentration = random_gen_dust_concentration();
-    let air_purity = AirPurity::from_value(dust_concentration.parse::<u16>().unwrap()).to_string();
+    let air_purity = AirPurity::from_value(dust_concentration).to_string();
     let reading = Reading::new(
         random_gen_temperature(),
         random_gen_humidity(),
         random_gen_pressure(),
         dust_concentration,
-        air_purity
+        air_purity,
     );
 
     let json = serde_json::to_string(&reading).unwrap();
@@ -137,12 +142,13 @@ pub fn run(cli: &Cli) {
         .send();
 
     match res {
-        Ok(response) => {
-            match cli.debug {
-                true => println!("Response from Ambi backend: {:#?}", response),
-                false => println!("Response from Ambi backend: {:?}", response.status().as_str())
-            }
-        }
+        Ok(response) => match cli.debug {
+            true => println!("Response from Ambi backend: {:#?}", response),
+            false => println!(
+                "Response from Ambi backend: {:?}",
+                response.status().as_str()
+            ),
+        },
         Err(e) => {
             match cli.debug {
                 // Print out the entire reqwest::Error for verbose debugging
@@ -165,45 +171,44 @@ pub fn run(cli: &Cli) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use regex::Regex;
+    // use regex::Regex;
 
-    #[test]
-    fn random_gen_humidity_returns_correctly_formatted_humidity_data() {
-      let result = random_gen_humidity();
-      let regex = Regex::new(r"\d{1,2}.\d{1}").unwrap();
+    // #[test]
+    // fn random_gen_humidity_returns_correctly_formatted_humidity_data() {
+    //     let result = random_gen_humidity();
+    //     let regex = Regex::new(r"\d{1,2}.\d{1}").unwrap();
 
-      assert!(regex.is_match(&result));
-    }
-    
-    #[test]
-    fn random_gen_temperature_returns_correctly_formatted_humidity_data() {
-      let result = random_gen_temperature();
-      let regex = Regex::new(r"\d{1,2}.\d{1}").unwrap();
+    //     assert!(regex.is_match(&result));
+    // }
+    // #[test]
+    // fn random_gen_temperature_returns_correctly_formatted_humidity_data() {
+    //     let result = random_gen_temperature();
+    //     let regex = Regex::new(r"\d{1,2}.\d{1}").unwrap();
 
-      assert!(regex.is_match(&result));
-    }
+    //     assert!(regex.is_match(&result));
+    // }
 
-    #[test]
-    fn random_gen_pressure_returns_correctly_formatted_pressure_data() {
-        let result = random_gen_pressure();
-        let regex = Regex::new(r"\d{3,4}").unwrap();
-        assert!(regex.is_match(&result));
-    }
+    // #[test]
+    // fn random_gen_pressure_returns_correctly_formatted_pressure_data() {
+    //     let result = random_gen_pressure();
+    //     let regex = Regex::new(r"\d{3,4}").unwrap();
+    //     assert!(regex.is_match(&result));
+    // }
 
-    #[test]
-    fn random_gen_dust_concentration_returns_correctly_formatted_pressure_data() {
-        let result = random_gen_dust_concentration();
-        let regex = Regex::new(r"\d{0,4}").unwrap();
-        assert!(regex.is_match(&result));
-    }
+    // #[test]
+    // fn random_gen_dust_concentration_returns_correctly_formatted_pressure_data() {
+    //     let result = random_gen_dust_concentration();
+    //     let regex = Regex::new(r"\d{0,4}").unwrap();
+    //     assert!(regex.is_match(&result));
+    // }
 
     #[test]
     fn air_purity_from_value_returns_correct_enum() {
         let mut rng = thread_rng();
-        let fresh_air = rng.gen_range(0..=50);
+        let fresh_air = rng.gen_range(i32::MIN..=50);
         let low = rng.gen_range(51..=100);
         let high = rng.gen_range(101..=150);
-        let dangerous = rng.gen_range(151..u16::MAX);
+        let dangerous = rng.gen_range(151..i32::MAX);
 
         assert_eq!(AirPurity::from_value(fresh_air), AirPurity::FreshAir);
         assert_eq!(AirPurity::from_value(low), AirPurity::Low);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ struct Reading {
     temperature: f64,
     humidity: f64,
     pressure: i32,
-    dust_concentration: i32,
+    dust_concentration: f64,
     air_purity: String,
 }
 
@@ -47,7 +47,7 @@ impl Reading {
         temperature: f64,
         humidity: f64,
         pressure: i32,
-        dust_concentration: i32,
+        dust_concentration: f64,
         air_purity: String,
     ) -> Reading {
         Reading {
@@ -69,13 +69,13 @@ enum AirPurity {
 }
 
 impl AirPurity {
-    fn from_value(value: i32) -> AirPurity {
+    fn from_value(value: f64) -> AirPurity {
         match value {
-            i32::MIN..=50 => return AirPurity::FreshAir,
-            51..=100 => return AirPurity::Low,
-            101..=150 => return AirPurity::High,
-            151.. => return AirPurity::Dangerous,
-        };
+            value if value >= f64::MIN && value <= 50.0 => return AirPurity::FreshAir,
+            value if value > 50.0 && value <= 100.0 => return AirPurity::Low,
+            value if value > 100.0 && value <= 150.0 => return AirPurity::High,
+            _ => return AirPurity::Dangerous,
+        }
     }
 }
 
@@ -111,9 +111,10 @@ fn random_gen_pressure() -> i32 {
     rng.gen_range(900..=1100)
 }
 
-fn random_gen_dust_concentration() -> i32 {
+fn random_gen_dust_concentration() -> f64 {
     let mut rng = thread_rng();
-    rng.gen_range(0..=1000)
+    let value = rng.gen_range(0.0..=1000.0);
+    f64::trunc(value * 100.0) / 100.0
 }
 
 pub fn run(cli: &Cli) {
@@ -175,10 +176,10 @@ mod tests {
     #[test]
     fn air_purity_from_value_returns_correct_enum() {
         let mut rng = thread_rng();
-        let fresh_air = rng.gen_range(i32::MIN..=50);
-        let low = rng.gen_range(51..=100);
-        let high = rng.gen_range(101..=150);
-        let dangerous = rng.gen_range(151..i32::MAX);
+        let fresh_air = rng.gen_range(0.0..=50.0);
+        let low = rng.gen_range(51.0..=100.0);
+        let high = rng.gen_range(101.0..=150.0);
+        let dangerous = rng.gen_range(151.0..f64::MAX);
 
         assert_eq!(AirPurity::from_value(fresh_air), AirPurity::FreshAir);
         assert_eq!(AirPurity::from_value(low), AirPurity::Low);


### PR DESCRIPTION
I added stronger typing to the Reading struct. The types used were mostly dictated by the Rust to Postgresql type mapping that Diesel implements. 
I removed some test that were no longer valid. I didn't replace any since I felt the type system was already doing basically the same sort of checks. If you have any suggestions on additional tests that you think should be added then let me know.

This has been tested against ambi (Elixir) and the initial implementation of ambi-rs that is still in PR. It could successfully post readings to both.